### PR TITLE
Fix typo in docs, in the marshalling.rst intro

### DIFF
--- a/doc/marshalling.rst
+++ b/doc/marshalling.rst
@@ -7,7 +7,7 @@ Response marshalling
 
 
 Flask-RESTX provides an easy way to control what data you actually render in
-your response or expect as in input payload.
+your response or expect as an input payload.
 With the :mod:`~.fields` module, you can use whatever objects (ORM
 models/custom classes/etc.) you want in your resource.
 :mod:`~.fields` also lets you format and filter the response


### PR DESCRIPTION
This commit fixes a typo in the first sentence of the first paragraph of "Response marshalling".